### PR TITLE
[PDE-2585] Use dependabot to keep the libraries up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/destination"
+    schedule:
+      interval: daily
+    allow:
+      # Only use dependabot to monitor for Sprig & Segment updates
+      - dependency-name: "com.segment.analytics.kotlin:android"
+      - dependency-name: "com.userleap:userleap-android-sdk"


### PR DESCRIPTION
This adds a dependbot configuration file to monitor daily for any updates to the Sprig or Segment plugins that are used