### PR TITLE
[PDE-4288] Add additional kotlinx.Serialization Proguard rules

### DIFF
--- a/destination/proguard-rules.pro
+++ b/destination/proguard-rules.pro
@@ -1,21 +1,40 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# From https://github.com/Kotlin/kotlinx.serialization#android
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+# Serializer for classes with named companion objects are retrieved using `getDeclaredClasses`.
+# If you have any, uncomment and replace classes with those containing named companion objects.
+#-keepattributes InnerClasses # Needed for `getDeclaredClasses`.
+#-if @kotlinx.serialization.Serializable class
+#com.example.myapplication.HasNamedCompanion, # <-- List serializable classes with named companions.
+#com.example.myapplication.HasNamedCompanion2
+#{
+#    static **$* *;
 #}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+#-keepnames class <1>$$serializer { # -keepnames suffices; class is kept when serializer() is kept.
+#    static <1>$$serializer INSTANCE;
+#}

--- a/destination/src/main/java/com/userleap/destination/SprigDestination.kt
+++ b/destination/src/main/java/com/userleap/destination/SprigDestination.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.lang.ref.WeakReference
 
+@Keep
 @Serializable
 data class SprigSettings(val envId: String)
 


### PR DESCRIPTION
# Add additional ProGuard Rules

<!--- Provide a general summary of your changes in the Title above -->

## Description

Pull in the Serialization ProGuard rules from https://github.com/Kotlin/kotlinx.serialization#android since they aren't being applied from the Segment consumer rules

## Motivation and Context

https://sprig-inc.atlassian.net/browse/PDE-4288

## How Has This Been Tested?

Using a minified debug build, I verified that the Serializer mappings are correct in the generated `mapping.txt` and are not removed by checking `usage.txt`

- [ ] I have added automated tests for my changes
- [x] I have manually QA'd my changes (please include Loom link showing local/staging testing)
- [ ] I have deployed / will imminently deploy my changes to [list environment here]

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which should have no user-facing impact)
- [ ] Repeat Operational Action such as scaling or cloning resources (non-breaking change which fixes an issue)
- [ ] New resource or application (new infrastructure component that requires additional monitoring)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected. Please use feature flags here if possible and ensure the frontend and backend can be safely deployed separately)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- https://www.notion.so/userleap/Day-To-Day-Development-7682fdcdd7b147368ef430657fa187bd -->

- [ ] My change requires a change to the documentation, so I have coordinated to update the docs. <!--- https://docs.sprig.com/docs -->
- [ ] I have added alerting (for new resources).
- [ ] I have added new IAM roles following least-privilege practices (for new resources).
- [ ] Network changes to Sprig resources/third parties are included, and I have taken every precaution to limit potential data exposure using best-practice encryption and secure connection
- [x] No, network changes are not involved