### PR TITLE
Fix dependency resolution when running the release job

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -61,5 +61,8 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'com.segment.analytics.kotlin:android:1.7.0'
-    implementation "com.userleap:segment-analytics-kotlin-destination:${sdkVersionName()}"
+
+    // Change the comment between these two lines to test releases locally
+    implementation project(":destination")
+    //implementation "com.userleap:segment-analytics-kotlin-destination:${sdkVersionName()}"
 }


### PR DESCRIPTION
The example project was requiring the destination artifact that hasn't been published yet during the release process. This separates the testing version from the version that is used to publish the example app so we can complete the release job