### PR TITLE
attach package version for configure call

### DIFF
--- a/destination/src/main/java/com/userleap/destination/SprigDestination.kt
+++ b/destination/src/main/java/com/userleap/destination/SprigDestination.kt
@@ -40,7 +40,15 @@ class SprigDestination(
         super.update(settings, type)
         sprigSettings = settings.destinationSettings<SprigSettings>(key)?.also {
             it.envId.ifNotEmpty()?.let { environment ->
-                Sprig.configure(application, environment, mapOf("x-ul-installation-method" to "android-segment"))
+                val version = getVersion()
+                Sprig.configure(
+                    application,
+                    environment,
+                    mapOf(
+                        "x-ul-installation-method" to "android-segment",
+                        "x-ul-package-version" to version
+                    )
+                )
             }
         }
     }
@@ -124,6 +132,20 @@ class SprigDestination(
             value.toContent()?.let {
                 this[key] = it
             }
+        }
+    }
+
+    private fun getVersion(): String {
+        // Load version from version.properties file
+        try {
+            val versionProperties = Properties()
+            versionProperties.load(
+                SprigDestination::class.java.classLoader.getResourceAsStream("version.properties")
+            )
+            return versionProperties.getProperty("VERSION", "Unknown")
+        } catch (e: Exception) {
+            // Handle exceptions, log, or fallback to a default value
+            return "Unknown"
         }
     }
 

--- a/destination/src/main/java/com/userleap/destination/SprigDestination.kt
+++ b/destination/src/main/java/com/userleap/destination/SprigDestination.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.lang.ref.WeakReference
 import java.util.Properties
+import java.io.File
 
 @Keep
 @Serializable
@@ -138,16 +139,11 @@ class SprigDestination(
 
     private fun getVersion(): String {
         // Load version from version.properties file
-        try {
-            val versionProperties = Properties()
-            versionProperties.load(
-                SprigDestination::class.java.classLoader.getResourceAsStream("version.properties")
-            )
-            return versionProperties.getProperty("VERSION", "Unknown")
-        } catch (e: Exception) {
-            // Handle exceptions, log, or fallback to a default value
-            return "Unknown"
-        }
+        val rootDir = System.getProperty("user.dir")
+        val versionPropertiesFile = java.io.File(rootDir, "version.properties").absoluteFile
+        val versionProperties = Properties()
+        versionProperties.load(versionPropertiesFile.inputStream())
+        return versionProperties["VERSION"]?.toString() ?: "0.0.0"
     }
 
     companion object {

--- a/destination/src/main/java/com/userleap/destination/SprigDestination.kt
+++ b/destination/src/main/java/com/userleap/destination/SprigDestination.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.lang.ref.WeakReference
+import java.util.Properties
 
 @Keep
 @Serializable

--- a/destination/src/test/java/com/userleap/destination/SprigDestinationTests.kt
+++ b/destination/src/test/java/com/userleap/destination/SprigDestinationTests.kt
@@ -28,7 +28,7 @@ class SprigDestinationTests {
 
     @Test
     fun `settings are updated correctly`() {
-        every { Sprig.configure(any(), TEST_ENV, mapOf("x-ul-installation-method" to "android-segment")) } returns Unit
+        every { Sprig.configure(any(), TEST_ENV, mapOf("x-ul-installation-method" to "android-segment", "x-ul-package-version" to any())) } returns Unit
 
         // An simple settings blob
         val settingsBlob: Settings = Json.decodeFromString(
@@ -50,7 +50,7 @@ class SprigDestinationTests {
         assertEquals(sprigDestination.sprigSettings?.envId, TEST_ENV)
 
         // Verify Sprig was configured with the envId
-        verify(exactly = 1) { Sprig.configure(any(), TEST_ENV, mapOf("x-ul-installation-method" to "android-segment")) }
+        verify(exactly = 1) { Sprig.configure(any(), TEST_ENV, mapOf("x-ul-installation-method" to "android-segment", "x-ul-package-version" to any())) }
     }
 
     @Test


### PR DESCRIPTION
currently we store just the package version (e.g. 1.2.1) for android-segment in the sdkVersions table
but only the mobile-sdk-version header is used for recording sdk diagnostics, so therell be mistmatch of versions which means it wont be shown on the sdk & traffic page
this sends a new header which will have the package version