### PR TITLE
Bump Android SDK to 2.16.5. Release plugin version 1.2.3.

### DIFF
--- a/destination/build.gradle
+++ b/destination/build.gradle
@@ -87,5 +87,5 @@ dependencies {
     implementation 'androidx.fragment:fragment:1.3.6'
 
     // The Sprig SDK
-    implementation "com.userleap:userleap-android-sdk:2.16.4"
+    implementation "com.userleap:userleap-android-sdk:2.16.5"
 }

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Update this version to set the next version to be tagged after merging to main
 # Use only version numbers here, _do not_ lead with a v like v2.16.1
-VERSION=1.2.2
+VERSION=1.2.3


### PR DESCRIPTION
# Description

- chore: Bump Sprig Android SDK version to 2.16.5